### PR TITLE
Allow the instanciation of a TextButton without a loc defined

### DIFF
--- a/pygwidgets/pygwidgets.py
+++ b/pygwidgets/pygwidgets.py
@@ -726,7 +726,7 @@ class TextButton(PygWidgetsButton):
 
     MINIMUM_WIDTH = 100
 
-    def __init__(self, window, loc, text, width=None, height=40, textColor=PYGWIDGETS_BLACK, 
+    def __init__(self, window, loc=(0,0), text="", width=None, height=40, textColor=PYGWIDGETS_BLACK, 
                  upColor=PYGWIDGETS_NORMAL_GRAY, overColor=PYGWIDGETS_OVER_GRAY, downColor=PYGWIDGETS_DOWN_GRAY, 
                  fontName=None, fontSize=20, soundOnClick=None, 
                  enterToActivate=False, callBack=None, nickname=None):


### PR DESCRIPTION
I think it should be possible to initialize a button without passing the location at initialization.
In my use case I need to know how wide the button will be before setting it's location.


Right now I have to do this:

```
self.btn = pygwidgets.TextButton(window=self.window, loc=(0, 0), ...)
```
and afterwards:
```
p1, p2 = <...> # do some calculations based on self.btn.rect
self.btn.setLoc((p1, p2))
```

I suppose this might be true for more components. Let me know your thoughts.

Thanks in advance.