### PR TITLE
Fix bug when running setLoc in InputText

### DIFF
--- a/pygwidgets/pygwidgets.py
+++ b/pygwidgets/pygwidgets.py
@@ -2240,6 +2240,14 @@ class InputText(PygWidget):
 
         self.oNextFieldOnTab = oNextFieldOnTab
 
+    def setLoc(self, loc):
+        super().setLoc(loc)
+        self.imageRect = pygame.Rect(self.loc[0], self.loc[1], self.width, self.height)
+        self.rect = pygame.Rect(self.loc[0], self.loc[1], self.width, self.height)
+        # Set the rect of the focus highlight rectangle (when the text has been clicked on and has focus)
+        self.focusedImageRect = pygame.Rect(self.loc[0] - 3, self.loc[1] - 3, self.width + 6, self.height + 6)
+        self.cursorLoc = [self.loc[0], self.loc[1]]  # this is a list because element 0 will change as the user edits
+
 #
 #
 # DRAGGER


### PR DESCRIPTION
When running setLoc in InputText (after initialization), the fields: imageRect, rect, focusedImageRect and cursorLoc are still using the old loc. This causes a weird behaviour where you need to click the previous location to be able to edit the input field and the animations also happen in the wrong place.

Example:

![image](https://user-images.githubusercontent.com/45536168/221368376-09b441b1-fae8-4f2a-ba18-13aada5bc19b.png)
